### PR TITLE
FIX BUG: unable to read msg Topic

### DIFF
--- a/src/MQTT2Ravelli/MQTT2Ravelli.ino
+++ b/src/MQTT2Ravelli/MQTT2Ravelli.ino
@@ -219,11 +219,10 @@ void FixQuery_FixReply(uint8_t Query[], uint8_t QueryL, uint8_t TReply[], uint8_
 void callback(char *msgTopic, byte *msgPayload, unsigned int msgLength) {
   String ReqType = "";
   String ValTemp = "";
-
+  ReqType = msgTopic;
   // Get request type and if it exist the requested value
   for (int i = 0; i < msgLength; i++) {
     ValTemp += ((char)msgPayload[i]);
-    ReqType = msgTopic;
   }
   uint8_t ReqValue = ValTemp.toInt();
   


### PR DESCRIPTION
brought out from the loop the initialization of the string msg_topic. Before this fix the program was unable to read the topic and the answer was always "ERROR: request not recognized" since the string was empty.